### PR TITLE
fix: PersistentPreRunE not PreRunE

### DIFF
--- a/cmd/ketch/commands/root.go
+++ b/cmd/ketch/commands/root.go
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Short:            version.Description,
 	Version:          version.String(),
 	TraverseChildren: true,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return err
@@ -28,7 +28,7 @@ var rootCmd = &cobra.Command{
 
 		envFiles := []string{".env", path.Join(homeDir, ".ketchrc"), ".ketchrc", configFile}
 		for _, file := range envFiles {
-			if _, err := os.Stat(file); err == nil {
+			if f, err := os.Stat(file); err == nil && !f.IsDir() {
 				_ = godotenv.Overload(file)
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Use `PersistentPreRunE` not `PreRunE` as the former runs on all child commands whereas the latter only runs if the root command is executed (which it isn't).
Also check the env file specified isn't a directory

## Why is this change being made?
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran locally

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and Secure Coding Practices have been observed.
- [X] I have informed stakeholders of my changes.
