### PR TITLE
fix(validate): check for existence of logo file path in validate

### DIFF
--- a/apps/publish.go
+++ b/apps/publish.go
@@ -532,7 +532,6 @@ func getFileData(link string) ([]byte, error) {
 
 func getRemoteFileData(url string) ([]byte, error) {
 	resp, err := http.Get(url)
-	fmt.Printf("%v", resp)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +561,8 @@ func localFilePathExists(link string) (bool, error) {
 	logoFileInfo, err :=  os.Stat(link)
 	if err != nil {
 		return false, err
-	} else if logoFileInfo.IsDir() {
+	}
+	if logoFileInfo.IsDir() {
 		return false, errors.New(fmt.Sprintf("app config invalid: logo.link %s is a directory", link))
 	}
 	return true, nil

--- a/apps/publish.go
+++ b/apps/publish.go
@@ -532,6 +532,7 @@ func getFileData(link string) ([]byte, error) {
 
 func getRemoteFileData(url string) ([]byte, error) {
 	resp, err := http.Get(url)
+	fmt.Printf("%v", resp)
 	if err != nil {
 		return nil, err
 	}
@@ -559,14 +560,13 @@ func remoteFileDataExists(link string) (bool, error) {
 func localFilePathExists(link string) (bool, error) {
 
 	logoFileInfo, err :=  os.Stat(link)
+	//_, err :=  os.Stat(link)
 	if err != nil {
 		return false, err
 	} else if logoFileInfo.IsDir() {
 		return false, errors.New(fmt.Sprintf("app config invalid: logo.link %s is a directory", link))
-	} else {
-		return true, nil
 	}
-
+	return true, nil
 }
 
 func filePathExists(link string) (bool, error) {

--- a/apps/publish.go
+++ b/apps/publish.go
@@ -560,7 +560,6 @@ func remoteFileDataExists(link string) (bool, error) {
 func localFilePathExists(link string) (bool, error) {
 
 	logoFileInfo, err :=  os.Stat(link)
-	//_, err :=  os.Stat(link)
 	if err != nil {
 		return false, err
 	} else if logoFileInfo.IsDir() {

--- a/apps/publish.go
+++ b/apps/publish.go
@@ -321,8 +321,10 @@ func validateAppConfig(publishAppConfig ManifestInputs) error {
 		return errors.New(fmt.Sprintf("app config invalid: %s", errs))
 	}
 
-	if publishAppConfig.Type != AppTypeCustom {
-		return nil
+	if publishAppConfig.Logo != nil && len(publishAppConfig.Logo.Link) > 0 {
+		if _, err := filePathExists(publishAppConfig.Logo.Link); err != nil {
+			return err
+		}
 	}
 
 	if len(publishAppConfig.IdentitySpaces) > 0 {
@@ -544,4 +546,32 @@ func getLocalFileData(link string) ([]byte, error) {
 	}
 
 	return ioutil.ReadFile(link)
+}
+
+func remoteFileDataExists(link string) (bool, error) {
+	_, err := getRemoteFileData(link)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func localFilePathExists(link string) (bool, error) {
+
+	logoFileInfo, err :=  os.Stat(link)
+	if err != nil {
+		return false, err
+	} else if logoFileInfo.IsDir() {
+		return false, errors.New(fmt.Sprintf("app config invalid: logo.link %s is a directory", link))
+	} else {
+		return true, nil
+	}
+
+}
+
+func filePathExists(link string) (bool, error) {
+	if isRemoteLink(link) {
+		return remoteFileDataExists(link)
+	}
+	return localFilePathExists(link)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
At app validation, add a check for the existence of the logo link specified in the manifest config file. Without this check at the validation step, if the logo image file does not exist or is not accessible, app publication fails, so this fix is to catch this problem at the validation step.

## Why is this change being made?
- [X ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
https://switchbit.atlassian.net/browse/KD-1175

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and Secure Coding Practices have been observed.
- [X] I have informed stakeholders of my changes.
