### PR TITLE
fix(idsp): allow app identity spaces to not start with prefix `appCode.`

### DIFF
--- a/apps/publish.go
+++ b/apps/publish.go
@@ -333,11 +333,6 @@ func validateAppConfig(publishAppConfig ManifestInputs) error {
 					"identitySpaces.code "+identitySpace.Code+" is not unique"))
 			}
 
-			if !isEntityCodeValid(publishAppConfig.Code, identitySpace.Code) {
-				return errors.New(fmt.Sprintf("app config invalid: %s",
-					"identitySpaces.code must start with \""+publishAppConfig.Code+".\""))
-			}
-
 			codes[identitySpace.Code] = struct{}{}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Ketch CLI checks for `{appCode}.{idspCode}` had formerly been skipped because appType = custom had not been specified in any of the apps. With latest update to `ketch-cli` the check is enforced again.

Actually we don't want the apps to require staring with prefix `{appCode}.{idspCode}` like `optimizely.email` because then will need to fix all appInstances installed to date.
So easiest to just leave as is

## Why is this change being made?
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Will see successful run of ketch-cli at app such as at optimizely app

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and Secure Coding Practices have been observed.
- [x] I have informed stakeholders of my changes.
