### PR TITLE
chore(paths): Use paths from the provided url

### DIFF
--- a/pkg/transponder/configure.go
+++ b/pkg/transponder/configure.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 )
 
@@ -29,7 +30,7 @@ func Configure(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	u.Path = fmt.Sprintf("/captain/connections/%s", args[0])
+	u.Path = path.Join(u.Path, "/captain/connections", args[0])
 
 	client := http.Client{}
 

--- a/pkg/transponder/ls.go
+++ b/pkg/transponder/ls.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -26,7 +27,7 @@ func List(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	u.Path = "/captain/connections"
+	u.Path = path.Join(u.Path, "/captain/connections")
 
 	client := http.Client{}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.16.9. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Use the paths from the provided URL.

## Why is this change being made?
- [X] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
```
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦ go build -o $GOBIN/ketch ./cmd/ketch/main.go                                                                                                                                                 13:18:00
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦ ketch transponder --url http://localhost:5005/asdf ls                                                                                                                                        13:18:03
Error: Get "http://localhost:5005/asdf/captain/connections": dial tcp [::1]:5005: connect: connection refused
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦ ketch transponder --url http://localhost:5005/transponder1/blah ls                                                                                                                           13:18:19
Error: Get "http://localhost:5005/transponder1/blah/captain/connections": dial tcp [::1]:5005: connect: connection refused
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦ ketch transponder --url http://localhost:5005/ ls                                                                                                                                            13:18:29
Error: Get "http://localhost:5005/captain/connections": dial tcp [::1]:5005: connect: connection refused
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦                                                                                                                                                                                              13:18:36
```

Tested for configure as well
```
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦ ketch transponder --url http://localhost:5005/ configure                                                                                                                                     13:18:36
Error: accepts 1 arg(s), received 0
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦ ketch transponder --url http://localhost:5005/ configure asdf                                                                                                                                13:20:10
Initiating database connection
Error: Put "http://localhost:5005/captain/connections/asdf": dial tcp [::1]:5005: connect: connection refused
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦ ketch transponder --url http://localhost:5005/transponder/asdf configure asdf                                                                                                                13:20:13
Initiating database connection
Error: Put "http://localhost:5005/transponder/asdf/captain/connections/asdf": dial tcp [::1]:5005: connect: connection refused
⋊> ~/s/k/ketch-cli on algoboard/chore/ability-to-pass-paths-to-url ◦
```

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.
