### PR TITLE
chore(pr_comments): Use path.join for creating a fs path

### DIFF
--- a/pkg/transponder/configure.go
+++ b/pkg/transponder/configure.go
@@ -30,7 +30,7 @@ func Configure(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	u.Path = path.Join(u.Path, "/captain/connections", args[0])
+	u.Path = path.Join(u.Path, "captain", "connections", args[0])
 
 	client := http.Client{}
 

--- a/pkg/transponder/ls.go
+++ b/pkg/transponder/ls.go
@@ -27,7 +27,7 @@ func List(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	u.Path = path.Join(u.Path, "/captain/connections")
+	u.Path = path.Join(u.Path, "/captain", "connections")
 
 	client := http.Client{}
 

--- a/winch.yml
+++ b/winch.yml
@@ -14,7 +14,7 @@ release:
     - ./bin/linux-amd64/
     - ./bin/windows-amd64/
 dockers:
-  - dockerfile: Dockerfile
+  - dockerfile: docker/ketch/Dockerfile
     server: ghcr.io
     organization: ketch-com
     repository: ketch-cli


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.16.9. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Address the pr comments;  Also make the build succeed.

## Why is this change being made?
- [X] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by running `winch ci --dry-run`
```
⋊> ~/s/k/ketch-cli on algoboard/chore/pr-comments ◦ winch ci --dry-run                                                                                                                                                                                            14:50:23
Performing a dry run build
Version: 1.3.1
Prerelease:
Creating changelog
Creating version
Installing
Download modules
go mod download
Building
sh ./scripts/build.sh darwin linux windows
Building for darwin amd64...
|- ketch
|--> copied to ~/go/bin
Building for darwin arm64...
|- ketch
Building for linux amd64...
|- ketch
Building for windows amd64...
|- ketch
⋊> ~/s/k/ketch-cli on algoboard/chore/pr-comments ⨯ ls -l .build/                                                                                                                                                                                                 14:51:12
total 0
drwxr-xr-x  3 anirudhan  staff  96 Sep  6 14:50 darwin-amd64/
drwxr-xr-x  3 anirudhan  staff  96 Sep  6 14:50 darwin-arm64/
drwxr-xr-x  3 anirudhan  staff  96 Sep  6 14:51 linux-amd64/
drwxr-xr-x  3 anirudhan  staff  96 Sep  6 14:51 windows-amd64/
⋊> ~/s/k/ketch-cli on algoboard/chore/pr-comments ⨯ ls -l .build/**/*                                                                                                                                                                                             14:51:20
-rwxr-xr-x  1 anirudhan  staff  13054144 Sep  6 14:50 .build/darwin-amd64/ketch*
-rwxr-xr-x  1 anirudhan  staff  12787506 Sep  6 14:50 .build/darwin-arm64/ketch*
-rwxr-xr-x  1 anirudhan  staff  13232064 Sep  6 14:51 .build/linux-amd64/ketch*
-rwxr-xr-x  1 anirudhan  staff  13578752 Sep  6 14:51 .build/windows-amd64/ketch*

.build/darwin-amd64:
total 25504
-rwxr-xr-x  1 anirudhan  staff  13054144 Sep  6 14:50 ketch*

.build/darwin-arm64:
total 24976
-rwxr-xr-x  1 anirudhan  staff  12787506 Sep  6 14:50 ketch*

.build/linux-amd64:
total 25848
-rwxr-xr-x  1 anirudhan  staff  13232064 Sep  6 14:51 ketch*

.build/windows-amd64:
total 26528
-rwxr-xr-x  1 anirudhan  staff  13578752 Sep  6 14:51 ketch*
⋊> ~/s/k/ketch-cli on algoboard/chore/pr-comments ⨯
```

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
